### PR TITLE
`reloadDocument` argument FALSE by default in `Link()` and `NavLink()…

### DIFF
--- a/R/components.R
+++ b/R/components.R
@@ -75,13 +75,13 @@ Route <- function(..., element, key = uuid::UUIDgenerate()) {
 #' Link
 #' 
 #' The `reloadDocument` can be used to skip client side routing and let the 
-#' browser handle the transition normally (as if it were an <a href>). In 
-#' React Router v6 `reloadDocument` if `FALSE`, but given shiny behavior, the
-#' `Link()` function makes it `TRUE` by default.
+#' browser handle the transition normally (as if it were an <a href>). Given 
+#' shiny behavior, using `reloadDocument = TRUE` allows to render correctly
+#' objects created in the server side.
 #' 
 #' @rdname Link
 #' @param ... Props to pass to element.
-#' @param reloadDocument Boolean. Default TRUE. Let browser handle the transition normally 
+#' @param reloadDocument Boolean. Default FALSE.
 #' @return A Link component.
 #' @export
 Link <- function(..., reloadDocument = TRUE) {
@@ -107,13 +107,13 @@ Navigate <- component('Navigate')
 #' NavLink
 #' 
 #' The `reloadDocument` can be used to skip client side routing and let the 
-#' browser handle the transition normally (as if it were an <a href>). In 
-#' React Router v6 `reloadDocument` if `FALSE`, but given shiny behavior, the
-#' `NavLink()` function makes it `TRUE` by default.
+#' browser handle the transition normally (as if it were an <a href>). Given 
+#' shiny behavior, using `reloadDocument = TRUE` allows to render correctly
+#' objects created in the server side.
 #' 
 #' @rdname NavLink
 #' @param ... Props to pass to element.
-#' @param reloadDocument Boolean. Default TRUE. Let browser handle the transition normally 
+#' @param reloadDocument Boolean. Default FALSE.
 #' @return A NavLink component.
 #' @export
 NavLink <- function(..., reloadDocument = TRUE) {

--- a/inst/examples/dynamic-segment/app.R
+++ b/inst/examples/dynamic-segment/app.R
@@ -90,12 +90,14 @@ ui <- reactRouter::HashRouter(
           nav_item(
             NavLink(
               to = "overview", 
+              reloadDocument = TRUE,
               "Overview"
             )
           ),
           nav_item(
             NavLink(
               to = "analysis", 
+              reloadDocument = TRUE,
               "Analysis"
             )
           ),
@@ -103,6 +105,7 @@ ui <- reactRouter::HashRouter(
           nav_item(
             NavLink(
               to = "/", 
+              reloadDocument = TRUE,
               shiny::icon("home")
             )
           ),

--- a/man/Link.Rd
+++ b/man/Link.Rd
@@ -6,7 +6,7 @@
 \alias{updateLink.shinyInput}
 \title{Link}
 \usage{
-Link(..., reloadDocument = FALSE)
+Link(..., reloadDocument = TRUE)
 
 Link.shinyInput(inputId, ..., reloadDocument = TRUE)
 

--- a/man/Link.Rd
+++ b/man/Link.Rd
@@ -6,7 +6,7 @@
 \alias{updateLink.shinyInput}
 \title{Link}
 \usage{
-Link(..., reloadDocument = TRUE)
+Link(..., reloadDocument = FALSE)
 
 Link.shinyInput(inputId, ..., reloadDocument = TRUE)
 
@@ -30,9 +30,9 @@ A Link component.
 }
 \description{
 The `reloadDocument` can be used to skip client side routing and let the 
-browser handle the transition normally (as if it were an <a href>). In 
-React Router v6 `reloadDocument` if `FALSE`, but given shiny behavior, the
-`Link()` function makes it `TRUE` by default.
+browser handle the transition normally (as if it were an <a href>). Given 
+shiny behavior, using `reloadDocument = TRUE` allows to render correctly
+objects created in the server side.
 
 \url{https://reactrouter.com/6.30.0/components/link}
 }

--- a/man/NavLink.Rd
+++ b/man/NavLink.Rd
@@ -6,7 +6,7 @@
 \alias{updateNavLink.shinyInput}
 \title{NavLink}
 \usage{
-NavLink(..., reloadDocument = FALSE)
+NavLink(..., reloadDocument = TRUE)
 
 NavLink.shinyInput(inputId, ..., reloadDocument = TRUE)
 

--- a/man/NavLink.Rd
+++ b/man/NavLink.Rd
@@ -6,7 +6,7 @@
 \alias{updateNavLink.shinyInput}
 \title{NavLink}
 \usage{
-NavLink(..., reloadDocument = TRUE)
+NavLink(..., reloadDocument = FALSE)
 
 NavLink.shinyInput(inputId, ..., reloadDocument = TRUE)
 
@@ -30,9 +30,9 @@ A NavLink component.
 }
 \description{
 The `reloadDocument` can be used to skip client side routing and let the 
-browser handle the transition normally (as if it were an <a href>). In 
-React Router v6 `reloadDocument` if `FALSE`, but given shiny behavior, the
-`NavLink()` function makes it `TRUE` by default.
+browser handle the transition normally (as if it were an <a href>). Given 
+shiny behavior, using `reloadDocument = TRUE` allows to render correctly
+objects created in the server side.
 
 \url{https://reactrouter.com/6.30.0/components/nav-link}
 }


### PR DESCRIPTION
…`. Update dynamic-segmnent example to add `reloadDocument = TRUE` in links